### PR TITLE
Fix Rust future-incompatibility warnings and clippy lints

### DIFF
--- a/crates/paymaster-cli/src/command/empty/mod.rs
+++ b/crates/paymaster-cli/src/command/empty/mod.rs
@@ -178,7 +178,7 @@ pub async fn command_empty_paymaster(params: EmptyPaymasterParameters) -> Result
 
     // Load the configuration from the profile
     let configuration = ServiceConfiguration::from_file(&params.profile).unwrap();
-    let chain_id = configuration.starknet.chain_id.clone();
+    let chain_id = configuration.starknet.chain_id;
     let rpc_url = configuration.starknet.endpoint.clone();
 
     // Print the parameters to the user
@@ -188,7 +188,7 @@ pub async fn command_empty_paymaster(params: EmptyPaymasterParameters) -> Result
 
     let starknet = Client::new(&Configuration {
         endpoint: rpc_url,
-        chain_id: chain_id.clone(),
+        chain_id,
         fallbacks: vec![],
         timeout: configuration.starknet.timeout,
     });

--- a/crates/paymaster-cli/src/command/gas_tank/build.rs
+++ b/crates/paymaster-cli/src/command/gas_tank/build.rs
@@ -14,7 +14,7 @@ pub struct GasTankDeployment {
 
 impl GasTankDeployment {
     pub async fn build(starknet: &Client, private_key: Felt, fund: Felt) -> Result<Self, Error> {
-        let gas_tank_deployment = DeployArgentAccount::initialize(&starknet, private_key).await;
+        let gas_tank_deployment = DeployArgentAccount::initialize(starknet, private_key).await;
         // Fund the gas tank with the amount of STRK specified in the parameters (1 STRK will be used as reserve)
         let transfer_call = Transfer {
             token: Token::STRK_ADDRESS,

--- a/crates/paymaster-cli/src/command/relayer/build.rs
+++ b/crates/paymaster-cli/src/command/relayer/build.rs
@@ -54,7 +54,7 @@ impl RelayerDeployment {
     pub async fn build_many(starknet: &Client, forwarder: Felt, private_key: Felt, count: usize, fund: Felt) -> Result<Self, Error> {
         let mut deployment = vec![];
         for _ in 0..count {
-            deployment.push(RelayerDeployment::build_one(&starknet, forwarder, private_key, fund).await?);
+            deployment.push(RelayerDeployment::build_one(starknet, forwarder, private_key, fund).await?);
         }
 
         let calls = deployment.iter().fold(Calls::empty(), |mut calls, x| {

--- a/crates/paymaster-cli/src/command/relayer/rebalance.rs
+++ b/crates/paymaster-cli/src/command/relayer/rebalance.rs
@@ -43,7 +43,7 @@ pub async fn command_relayers_rebalance(params: RelayersRebalanceCommandParamete
 
     // Load the configuration from the profile
     let configuration = ServiceConfiguration::from_file(&params.profile).unwrap();
-    let chain_id = configuration.starknet.chain_id.clone();
+    let chain_id = configuration.starknet.chain_id;
     let rpc_url = configuration.starknet.endpoint.clone();
 
     // Print the parameters to the user
@@ -53,7 +53,7 @@ pub async fn command_relayers_rebalance(params: RelayersRebalanceCommandParamete
 
     let starknet = Client::new(&Configuration {
         endpoint: rpc_url,
-        chain_id: chain_id.clone(),
+        chain_id,
         fallbacks: vec![],
         timeout: configuration.starknet.timeout,
     });
@@ -73,7 +73,7 @@ pub async fn command_relayers_rebalance(params: RelayersRebalanceCommandParamete
     // Initialize the rebalancing service
     let rebalancing_service = RelayerRebalancingService::new(Context::new(RelayerManagerConfiguration {
         starknet: configuration.starknet.clone(),
-        gas_tank: configuration.gas_tank.clone(),
+        gas_tank: configuration.gas_tank,
         relayers: configuration.relayers.clone(),
         supported_tokens: configuration.supported_tokens.clone(),
     }))

--- a/crates/paymaster-execution/src/diagnostics/client.rs
+++ b/crates/paymaster-execution/src/diagnostics/client.rs
@@ -42,7 +42,7 @@ impl DiagnosticClient {
     /// It extracts diagnostics and logs them with appropriate tracing spans
     /// for CloudWatch/OTEL ingestion.
     pub async fn report(&self, calls: &Calls, user_address: Felt, error_message: String) {
-        let context = DiagnosticContext::new(&calls, &error_message, user_address);
+        let context = DiagnosticContext::new(calls, &error_message, user_address);
         for diagnostic in self.analyze(&context).await {
             self.log_diagnostic(&diagnostic);
         }

--- a/crates/paymaster-execution/src/diagnostics/extractors/mod.rs
+++ b/crates/paymaster-execution/src/diagnostics/extractors/mod.rs
@@ -37,6 +37,12 @@ use std::collections::HashMap;
 
 pub struct Metadata(pub HashMap<String, DiagnosticValue>);
 
+impl Default for Metadata {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Metadata {
     pub fn new() -> Self {
         Metadata(HashMap::new())

--- a/crates/paymaster-relayer/src/lock/mod.rs
+++ b/crates/paymaster-relayer/src/lock/mod.rs
@@ -116,7 +116,7 @@ pub enum LockLayer {
 impl LockLayer {
     pub fn new(configuration: &RelayerManagerConfiguration) -> Self {
         match &configuration.relayers.lock {
-            LockLayerConfiguration::Shared { redis, .. } => LockLayer::Shared(SharedLockLayer::new(configuration, &redis)),
+            LockLayerConfiguration::Shared { redis, .. } => LockLayer::Shared(SharedLockLayer::new(configuration, redis)),
             LockLayerConfiguration::Seggregated { .. } => LockLayer::Seggregated(SeggregatedLockLayer::new(configuration)),
 
             #[cfg(feature = "testing")]

--- a/crates/paymaster-relayer/src/rebalancing/mod.rs
+++ b/crates/paymaster-relayer/src/rebalancing/mod.rs
@@ -292,7 +292,7 @@ impl RelayerRebalancingService {
         relayers
     }
 
-    async fn has_at_least_one_relayer_below_trigger_balance(&self, relayers: &Vec<RelayerBalance>) -> bool {
+    async fn has_at_least_one_relayer_below_trigger_balance(&self, relayers: &[RelayerBalance]) -> bool {
         relayers
             .iter()
             .any(|relayer| relayer.balance < self.rebalancing_configuration.trigger_balance)

--- a/crates/paymaster-relayer/src/swap/client/avnu/mod.rs
+++ b/crates/paymaster-relayer/src/swap/client/avnu/mod.rs
@@ -41,7 +41,7 @@ impl AVNUSwapClient {
     async fn get_quote(&self, sell_token: Felt, buy_token: Felt, sell_amount: Felt, taker_address: Felt, max_price_impact: f64) -> Result<AVNUQuote, ServiceError> {
         let response = self
             .client
-            .get(&format!("{}/quotes", self.endpoint))
+            .get(format!("{}/quotes", self.endpoint))
             .query(&[
                 ("sellTokenAddress", &format!("0x{:x}", sell_token)),
                 ("buyTokenAddress", &format!("0x{:x}", buy_token)),
@@ -83,7 +83,7 @@ impl AVNUSwapClient {
 
         let response = self
             .client
-            .post(&format!("{}/build", self.endpoint))
+            .post(format!("{}/build", self.endpoint))
             .json(&request_body)
             .send()
             .await

--- a/crates/paymaster-relayer/src/swap/client/mod.rs
+++ b/crates/paymaster-relayer/src/swap/client/mod.rs
@@ -17,6 +17,7 @@ use crate::swap::client::mock::MockSwapClient;
 
 // Trait to be implemented by any swap client
 #[async_trait]
+#[allow(clippy::too_many_arguments)]
 pub trait Swap: 'static + Send + Sync + Clone {
     // Swap tokens and return the calls needed to execute the swap, and the minimum amount of token received
     async fn swap(
@@ -123,6 +124,7 @@ impl SwapClient {
         Self::Mock(Arc::new(I::new()))
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn swap(
         &self,
         sell_token: Felt,

--- a/crates/paymaster-service/src/core/context/configuration.rs
+++ b/crates/paymaster-service/src/core/context/configuration.rs
@@ -175,16 +175,12 @@ mod tests {
         let mut profile = Profile::empty();
 
         let value = Value::String("42".to_string());
-        profile.insert_variable(JSONPath::from_str("foo_1"), value.clone()).unwrap();
-        profile.insert_variable(JSONPath::from_str("foo_2"), value.clone()).unwrap();
+        profile.insert_variable(JSONPath::parse("foo_1"), value.clone()).unwrap();
+        profile.insert_variable(JSONPath::parse("foo_2"), value.clone()).unwrap();
+        profile.insert_variable(JSONPath::parse("foo_3.foo_1"), value.clone()).unwrap();
+        profile.insert_variable(JSONPath::parse("foo_3.foo_2"), value.clone()).unwrap();
         profile
-            .insert_variable(JSONPath::from_str("foo_3.foo_1"), value.clone())
-            .unwrap();
-        profile
-            .insert_variable(JSONPath::from_str("foo_3.foo_2"), value.clone())
-            .unwrap();
-        profile
-            .insert_variable(JSONPath::from_str("foo_3.foo_3.foo_1"), value.clone())
+            .insert_variable(JSONPath::parse("foo_3.foo_3.foo_1"), value.clone())
             .unwrap();
 
         assert_eq!(profile.0, expected);

--- a/crates/paymaster-service/src/core/context/mod.rs
+++ b/crates/paymaster-service/src/core/context/mod.rs
@@ -46,26 +46,26 @@ unless all variables are set via command line or environment variables."
     }
 }
 
-impl Into<paymaster_rpc::Configuration> for Context {
-    fn into(self) -> paymaster_rpc::Configuration {
+impl From<Context> for paymaster_rpc::Configuration {
+    fn from(val: Context) -> Self {
         paymaster_rpc::Configuration {
-            rpc: self.configuration.rpc,
+            rpc: val.configuration.rpc,
 
-            forwarder: self.configuration.forwarder,
-            gas_tank: self.configuration.gas_tank,
+            forwarder: val.configuration.forwarder,
+            gas_tank: val.configuration.gas_tank,
 
-            supported_tokens: self.configuration.supported_tokens,
+            supported_tokens: val.configuration.supported_tokens,
 
-            max_fee_multiplier: self.configuration.max_fee_multiplier,
-            provider_fee_overhead: self.configuration.provider_fee_overhead,
+            max_fee_multiplier: val.configuration.max_fee_multiplier,
+            provider_fee_overhead: val.configuration.provider_fee_overhead,
 
-            estimate_account: self.configuration.estimate_account,
+            estimate_account: val.configuration.estimate_account,
 
-            relayers: self.configuration.relayers,
+            relayers: val.configuration.relayers,
 
-            starknet: self.configuration.starknet,
-            price: self.configuration.price,
-            sponsoring: self.configuration.sponsoring,
+            starknet: val.configuration.starknet,
+            price: val.configuration.price,
+            sponsoring: val.configuration.sponsoring,
         }
     }
 }

--- a/crates/paymaster-starknet/src/client/mod.rs
+++ b/crates/paymaster-starknet/src/client/mod.rs
@@ -66,11 +66,7 @@ impl Deref for StarknetRPCClient {
 
 impl FailurePredicate<ProviderError> for StarknetRPCClient {
     fn is_err(&self, err: &ProviderError) -> bool {
-        match err {
-            ProviderError::RateLimited => true,
-            ProviderError::Other(_) => true,
-            _ => false,
-        }
+        matches!(err, ProviderError::RateLimited | ProviderError::Other(_))
     }
 }
 

--- a/crates/paymaster-starknet/src/transaction/call/mod.rs
+++ b/crates/paymaster-starknet/src/transaction/call/mod.rs
@@ -113,7 +113,7 @@ impl Calls {
     }
 
     pub fn as_execute_from_outside_call(&self, caller_address: Felt, to: StarknetAccount, to_private_key: Felt, time_bounds: TimeBounds) -> Call {
-        let to_address = to.address().clone();
+        let to_address = to.address();
         // Create execute_from_outside message
         let execute_from_outside_message = ExecuteFromOutsideMessage::new(
             PaymasterVersion::V1,
@@ -135,7 +135,7 @@ impl Calls {
         let signature = signing_key.sign(&message_hash).unwrap();
 
         // Create the execute_from_outside call
-        return execute_from_outside_message.to_call(to.address(), &vec![signature.r, signature.s]);
+        execute_from_outside_message.to_call(to.address(), &vec![signature.r, signature.s])
     }
 }
 

--- a/crates/paymaster-starknet/src/transaction/mod.rs
+++ b/crates/paymaster-starknet/src/transaction/mod.rs
@@ -146,7 +146,7 @@ impl ExecuteFromOutsideMessageV1 {
     }
 
     pub fn from_typed_data(value: &TypedData) -> Result<Self, Error> {
-        let decoder = TypedValueDecoder::new(&value.message());
+        let decoder = TypedValueDecoder::new(value.message());
         let object_decoder = decoder.decode_object()?;
 
         Ok(Self(ExecuteFromOutsideParameters {
@@ -276,7 +276,7 @@ impl ExecuteFromOutsideMessageV2 {
     }
 
     pub fn from_typed_data(value: &TypedData) -> Result<Self, Error> {
-        let decoder = TypedValueDecoder::new(&value.message());
+        let decoder = TypedValueDecoder::new(value.message());
         let object_decoder = decoder.decode_object()?;
 
         Ok(Self(ExecuteFromOutsideParameters {


### PR DESCRIPTION
## Summary

- Fix never type fallback issue in `paymaster-relayer` that will be rejected in Rust 2024 edition
- Fix all clippy warnings across the codebase when building with `-D warnings`

## Changes

### Future Incompatibility Fix (paymaster-relayer)
The `unlock` and `unlock_with_expiry` functions in `crates/paymaster-relayer/src/lock/shared/lock.rs` were using Redis calls without explicit type annotations, causing never type fallback warnings. Added explicit `()` type annotations to `set_ex` and `del` calls.

### Clippy Fixes
- Replace `impl Into<T>` with `impl From<T>` (clippy::from_over_into)
- Remove unnecessary `.clone()` on `Copy` types (clippy::clone_on_copy)
- Remove needless borrows and references (clippy::needless_borrow)
- Use `matches!` macro instead of match expressions (clippy::match_like_matches_macro)
- Implement `FromStr` and `IntoIterator` traits properly (clippy::should_implement_trait)
- Add `Default` impl for `Metadata` (clippy::new_without_default)
- Use `&[T]` instead of `&Vec<T>` in function parameters (clippy::ptr_arg)
- Add `#[allow(clippy::too_many_arguments)]` where appropriate

## Testing

- ✅ `cargo build` passes without future-incompatibility warnings
- ✅ `cargo test` passes
- ✅ `cargo clippy -- -D warnings` passes