### PR TITLE
refactor: extract gas transfer from execute_from_outside call

### DIFF
--- a/crates/paymaster-execution/src/execution/execute.rs
+++ b/crates/paymaster-execution/src/execution/execute.rs
@@ -128,7 +128,8 @@ impl ExecutableTransaction {
             return Err(Error::InvalidTypedData);
         }
 
-        // Parse all calls to find the last one and extract its details
+        // Parse calls to find where the last one starts and extract its details
+        // We need to iterate because each call has variable-length calldata
         let mut idx = num_calls_idx + 1;
         let mut last_call_token = Felt::ZERO;
         let mut last_call_selector = Felt::ZERO;
@@ -150,7 +151,7 @@ impl ExecutableTransaction {
                 return Err(Error::InvalidTypedData);
             }
 
-            // If this is the last call, extract all the details we need
+            // If this is the last call, extract all the details we need and we're done
             if i == num_calls - 1 {
                 // For a transfer call, calldata should be [recipient, amount_low, amount_high]
                 // We need at least recipient and amount_low
@@ -162,6 +163,7 @@ impl ExecutableTransaction {
                 last_call_selector = selector;
                 last_call_recipient = calldata[idx];
                 last_call_amount = calldata[idx + 1];
+                break;
             }
 
             idx += call_calldata_len;

--- a/crates/paymaster-execution/src/execution/execute.rs
+++ b/crates/paymaster-execution/src/execution/execute.rs
@@ -395,11 +395,11 @@ mod tests {
             felt!("0x4"), // execute_before
             Felt::ONE,    // num_calls = 1
             // Call with wrong selector
-            felt!("0x456"),        // to
-            selector!("approve"),  // wrong selector
-            Felt::TWO,             // calldata_len
-            forwarder,             // recipient
-            felt!("0x789"),        // amount
+            felt!("0x456"),       // to
+            selector!("approve"), // wrong selector
+            Felt::TWO,            // calldata_len
+            forwarder,            // recipient
+            felt!("0x789"),       // amount
         ];
 
         let call = Call {

--- a/crates/paymaster-execution/src/execution/execute.rs
+++ b/crates/paymaster-execution/src/execution/execute.rs
@@ -24,8 +24,6 @@ pub enum ExecutableTransactionParameters {
     RawInvoke {
         user: Felt,
         execute_from_outside_call: Call,
-        gas_token: Option<Felt>,
-        max_gas_token_amount: Option<Felt>,
     },
 }
 

--- a/crates/paymaster-rpc/src/endpoint/execute_raw.rs
+++ b/crates/paymaster-rpc/src/endpoint/execute_raw.rs
@@ -29,8 +29,6 @@ impl TryFrom<ExecuteRawTransactionParameters> for paymaster_execution::Executabl
             ExecuteRawTransactionParameters::RawInvoke { invoke } => Self::RawInvoke {
                 user: invoke.user_address,
                 execute_from_outside_call: invoke.execute_from_outside_call,
-                gas_token: None,            // Will be extracted from the call
-                max_gas_token_amount: None, // Will be extracted from the call
             },
         })
     }


### PR DESCRIPTION
This PR removes duplication between `ExecutionParameters.FeeMode` and the optional `gas_token`/`max_gas_token_amount` fields in `RawInvokeParameters`. The gas transfer information is now extracted directly from the signed `execute_from_outside_call`, making `FeeMode` the single source of truth for fee payment mode. This ensures consistency between the standard `build_transaction` flow and the raw execute flow.