### PR TITLE
Fix asdf latest version resolution

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -2,6 +2,30 @@
 
 set -euo pipefail
 
+resolve_version() {
+  local version="$1"
+  local list_all
+
+  version="$(printf "%s\n" "$version" | awk 'NF {last=$0} END {print last}')"
+  version="$(printf "%s" "$version" | tr -d '\r')"
+
+  if [[ "$version" == "latest" ]]; then
+    list_all="$(dirname "${BASH_SOURCE[0]}")/list-all"
+    if [[ ! -x "$list_all" ]]; then
+      echo "Error: list-all not found; cannot resolve latest" >&2
+      exit 1
+    fi
+    version="$("$list_all" | awk 'NF {last=$0} END {print last}')"
+  fi
+
+  if [[ -z "$version" ]]; then
+    echo "Error: Could not resolve version" >&2
+    exit 1
+  fi
+
+  printf "%s" "$version"
+}
+
 get_platform() {
   local os arch
 
@@ -66,6 +90,7 @@ main() {
   local download_path="${ASDF_DOWNLOAD_PATH}"
   local platform extension
 
+  version="$(resolve_version "$version")"
   platform="$(get_platform)"
   extension="$(get_extension)"
 

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+list_all="$(dirname "${BASH_SOURCE[0]}")/list-all"
+
+if [[ ! -x "$list_all" ]]; then
+  echo "Error: list-all not found; cannot resolve latest" >&2
+  exit 1
+fi
+
+"$list_all" | awk 'NF {last=$0} END {print last}'


### PR DESCRIPTION
Fix asdf downloads when ASDF_INSTALL_VERSION contains multiple lines by normalizing to a single version before constructing URLs. Add latest-stable script so asdf can resolve latest without multi-line output. This prevents malformed URLs for `asdf install paymaster latest`.