### PR TITLE
Fall back to Sepolia values for unknown chain IDs (copenhagen)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,6 +2698,7 @@ dependencies = [
  "paymaster-common",
  "reqwest",
  "serde",
+ "serde_json",
  "serde_with",
  "starknet",
  "testcontainers",

--- a/crates/paymaster-cli/src/command/setup/mod.rs
+++ b/crates/paymaster-cli/src/command/setup/mod.rs
@@ -116,8 +116,7 @@ pub async fn deploy_paymaster_core(params: SetupParameters, skip_user_confirmati
     info!("Starting Paymaster setup for profile: {}", params.profile);
 
     // Load the configuration
-    let chain_id = ChainID::from_string(&params.chain_id)
-        .map_err(|e| Error::Execution(format!("invalid chain-id {}: {}", params.chain_id, e)))?;
+    let chain_id = ChainID::from_string(&params.chain_id).map_err(|e| Error::Execution(format!("invalid chain-id {}: {}", params.chain_id, e)))?;
     let default_rpc_url = match chain_id {
         ChainID::Mainnet => DEFAULT_MAINNET_RPC_ENDPOINT,
         // Unknown chains have no canonical RPC; fall back to Sepolia's.

--- a/crates/paymaster-cli/src/command/setup/mod.rs
+++ b/crates/paymaster-cli/src/command/setup/mod.rs
@@ -116,10 +116,12 @@ pub async fn deploy_paymaster_core(params: SetupParameters, skip_user_confirmati
     info!("Starting Paymaster setup for profile: {}", params.profile);
 
     // Load the configuration
-    let chain_id = ChainID::from_string(&params.chain_id).expect("invalid chain-id");
+    let chain_id = ChainID::from_string(&params.chain_id)
+        .map_err(|e| Error::Execution(format!("invalid chain-id {}: {}", params.chain_id, e)))?;
     let default_rpc_url = match chain_id {
-        ChainID::Sepolia => DEFAULT_SEPOLIA_RPC_ENDPOINT,
         ChainID::Mainnet => DEFAULT_MAINNET_RPC_ENDPOINT,
+        // Unknown chains have no canonical RPC; fall back to Sepolia's.
+        ChainID::Sepolia | ChainID::Unknown(_) => DEFAULT_SEPOLIA_RPC_ENDPOINT,
     };
 
     let rpc_url = params.rpc_url.unwrap_or_else(|| default_rpc_url.to_string());

--- a/crates/paymaster-cli/src/command/setup/mod.rs
+++ b/crates/paymaster-cli/src/command/setup/mod.rs
@@ -117,13 +117,20 @@ pub async fn deploy_paymaster_core(params: SetupParameters, skip_user_confirmati
 
     // Load the configuration
     let chain_id = ChainID::from_string(&params.chain_id).map_err(|e| Error::Execution(format!("invalid chain-id {}: {}", params.chain_id, e)))?;
-    let default_rpc_url = match chain_id {
-        ChainID::Mainnet => DEFAULT_MAINNET_RPC_ENDPOINT,
-        // Unknown chains have no canonical RPC; fall back to Sepolia's.
-        ChainID::Sepolia | ChainID::Unknown(_) => DEFAULT_SEPOLIA_RPC_ENDPOINT,
-    };
 
-    let rpc_url = params.rpc_url.unwrap_or_else(|| default_rpc_url.to_string());
+    // Unknown chains have no canonical RPC; the operator must supply one
+    // explicitly. For Sepolia/Mainnet we fall back to the public default.
+    let rpc_url = match (&params.rpc_url, &chain_id) {
+        (Some(url), _) => url.clone(),
+        (None, ChainID::Sepolia) => DEFAULT_SEPOLIA_RPC_ENDPOINT.to_string(),
+        (None, ChainID::Mainnet) => DEFAULT_MAINNET_RPC_ENDPOINT.to_string(),
+        (None, ChainID::Unknown(_)) => {
+            return Err(Error::Execution(format!(
+                "an RPC URL must be provided for non-natively-supported chain id {}",
+                chain_id.as_identifier()
+            )))
+        },
+    };
     let gas_tank_fund_in_fri = normalize_felt(params.fund, 18);
     let estimate_account_fund_in_fri = normalize_felt(params.estimate_account_fund, 18);
     let num_relayers = params.num_relayers;

--- a/crates/paymaster-execution/src/diagnostics/client.rs
+++ b/crates/paymaster-execution/src/diagnostics/client.rs
@@ -28,8 +28,9 @@ impl DiagnosticClient {
     pub fn new(chain_id: ChainID) -> Self {
         let token_client = TokenClient::new(chain_id);
         let avnu_contract_address = match chain_id {
-            ChainID::Sepolia => AVNU_EXCHANGE_ADDRESS_SEPOLIA,
             ChainID::Mainnet => AVNU_EXCHANGE_ADDRESS_MAINNET,
+            // Unknown chains reuse the Sepolia AVNU exchange address.
+            ChainID::Sepolia | ChainID::Unknown(_) => AVNU_EXCHANGE_ADDRESS_SEPOLIA,
         };
         Self {
             extractors: vec![Arc::new(AvnuExtractor::new(avnu_contract_address, token_client))],

--- a/crates/paymaster-execution/src/tokens/mod.rs
+++ b/crates/paymaster-execution/src/tokens/mod.rs
@@ -79,10 +79,12 @@ impl TokenClient {
     }
 
     /// Creates a new token service based on chain ID.
+    ///
+    /// Unknown chains fall back to the Sepolia AVNU API.
     pub fn new(chain_id: ChainID) -> Self {
         match chain_id {
-            ChainID::Sepolia => Self::sepolia(),
             ChainID::Mainnet => Self::mainnet(),
+            ChainID::Sepolia | ChainID::Unknown(_) => Self::sepolia(),
         }
     }
 
@@ -183,6 +185,12 @@ mod tests {
         #[test]
         fn should_use_sepolia_url_for_sepolia_chain() {
             let client = TokenClient::new(ChainID::Sepolia);
+            assert_eq!(client.base_url, AVNU_API_SEPOLIA_URL);
+        }
+
+        #[test]
+        fn should_use_sepolia_url_for_unknown_chain() {
+            let client = TokenClient::new(ChainID::Unknown(Felt::from_hex("0x534e5f4b41545241").unwrap()));
             assert_eq!(client.base_url, AVNU_API_SEPOLIA_URL);
         }
     }

--- a/crates/paymaster-prices/src/avnu/mod.rs
+++ b/crates/paymaster-prices/src/avnu/mod.rs
@@ -49,8 +49,9 @@ pub struct AVNUPriceClientConfiguration {
 impl AVNUPriceClientConfiguration {
     pub fn default_from_chain(chain_id: ChainID) -> Self {
         match chain_id {
-            ChainID::Sepolia => Self::default_sepolia(),
             ChainID::Mainnet => Self::default_mainnet(),
+            // Unknown chains fall back to the Sepolia AVNU price endpoint.
+            ChainID::Sepolia | ChainID::Unknown(_) => Self::default_sepolia(),
         }
     }
 

--- a/crates/paymaster-relayer/src/swap/client/mod.rs
+++ b/crates/paymaster-relayer/src/swap/client/mod.rs
@@ -40,8 +40,9 @@ pub struct SwapClientConfiguration {
 impl SwapClientConfiguration {
     pub fn default_from_chain(chain_id: ChainID) -> Self {
         match chain_id {
-            ChainID::Sepolia => Self::default_sepolia(),
             ChainID::Mainnet => Self::default_mainnet(),
+            // Unknown chains fall back to the Sepolia AVNU swap config.
+            ChainID::Sepolia | ChainID::Unknown(_) => Self::default_sepolia(),
         }
     }
 
@@ -65,10 +66,8 @@ impl SwapClientConfiguration {
         if self.endpoint.is_empty() {
             return Err(ServiceError::new("AVNU endpoint cannot be empty"));
         }
-        // Validate chain ID
-        if self.chain_id.as_felt() != ChainID::Mainnet.as_felt() && self.chain_id.as_felt() != ChainID::Sepolia.as_felt() {
-            return Err(ServiceError::new("Swap service is only supported on Starknet mainnet & Sepolia testnet"));
-        }
+        // Any chain id is accepted: Mainnet/Sepolia use their respective AVNU
+        // deployments, and Unknown chains reuse the Sepolia configuration.
         Ok(())
     }
 }
@@ -144,5 +143,25 @@ impl SwapClient {
                     .await
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_unknown_chain_id() {
+        let config = SwapClientConfiguration {
+            endpoint: DEFAULT_SEPOLIA_AVNU_SWAP_ENDPOINT.to_string(),
+            chain_id: ChainID::Unknown(Felt::from_hex("0x534e5f4b41545241").unwrap()),
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn default_from_chain_unknown_falls_back_to_sepolia() {
+        let config = SwapClientConfiguration::default_from_chain(ChainID::Unknown(Felt::from_hex("0x534e5f4b41545241").unwrap()));
+        assert_eq!(config.endpoint, DEFAULT_SEPOLIA_AVNU_SWAP_ENDPOINT);
     }
 }

--- a/crates/paymaster-service/src/main.rs
+++ b/crates/paymaster-service/src/main.rs
@@ -1,6 +1,7 @@
 use paymaster_common::service::monitoring::Metric;
 use paymaster_common::service::{Error, ServiceManager};
-use tracing::info;
+use paymaster_starknet::ChainID;
+use tracing::{info, warn};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
 
@@ -21,6 +22,26 @@ async fn main() -> Result<(), Error> {
     let subscriber = Registry::default().with(fmt_layer).with(metric_layer);
 
     tracing::subscriber::set_global_default(subscriber).unwrap();
+
+    let chain_id = &context.configuration.starknet.chain_id;
+    match chain_id {
+        ChainID::Sepolia | ChainID::Mainnet => {
+            info!(
+                chain_id = %chain_id.as_identifier(),
+                chain_id_felt = %chain_id.as_felt().to_hex_string(),
+                "configured chain id"
+            );
+        },
+        ChainID::Unknown(felt) => {
+            warn!(
+                chain_id = %felt.to_hex_string(),
+                "configured chain id is NOT natively supported by the paymaster: \
+                 falling back to Sepolia defaults (USDC token, AVNU swap/token API, \
+                 AVNU exchange address, Coingecko mapping, default RPC URL). \
+                 The configured chain id felt is preserved for transaction signing."
+            );
+        },
+    }
 
     let mut services = ServiceManager::new(context);
     info!("starting services...");

--- a/crates/paymaster-service/src/main.rs
+++ b/crates/paymaster-service/src/main.rs
@@ -36,9 +36,10 @@ async fn main() -> Result<(), Error> {
             warn!(
                 chain_id = %felt.to_hex_string(),
                 "configured chain id is NOT natively supported by the paymaster: \
-                 falling back to Sepolia defaults (USDC token, AVNU swap/token API, \
-                 AVNU exchange address, Coingecko mapping, default RPC URL). \
-                 The configured chain id felt is preserved for transaction signing."
+                 falling back to Sepolia defaults for chain-derived configuration \
+                 (USDC token, AVNU swap/token API, AVNU exchange address, \
+                 Coingecko mapping). The configured chain id felt is preserved \
+                 unchanged for transaction signing and EIP-712 domain separation."
             );
         },
     }

--- a/crates/paymaster-starknet/Cargo.toml
+++ b/crates/paymaster-starknet/Cargo.toml
@@ -22,3 +22,6 @@ chrono = { workspace = true }
 testcontainers = { workspace = true, optional = true }
 tracing = { workspace = true, features = ['attributes'] }
 uuid = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/paymaster-starknet/src/constants.rs
+++ b/crates/paymaster-starknet/src/constants.rs
@@ -48,15 +48,16 @@ impl Token {
 
     pub const fn usdc(chain_id: &ChainID) -> Token {
         match chain_id {
-            ChainID::Sepolia => Token {
-                symbol: "USDC",
-                decimals: 6,
-                address: felt!("0x53b40a647cedfca6ca84f542a0fe36736031905a9639a7f19a3c1e66bfd5080"),
-            },
             ChainID::Mainnet => Token {
                 symbol: "USDC",
                 decimals: 6,
                 address: felt!("0x53c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8"),
+            },
+            // Sepolia and any unknown chain id fall back to the Sepolia USDC.
+            ChainID::Sepolia | ChainID::Unknown(_) => Token {
+                symbol: "USDC",
+                decimals: 6,
+                address: felt!("0x53b40a647cedfca6ca84f542a0fe36736031905a9639a7f19a3c1e66bfd5080"),
             },
         }
     }

--- a/crates/paymaster-starknet/src/network.rs
+++ b/crates/paymaster-starknet/src/network.rs
@@ -1,74 +1,78 @@
 use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use starknet::core::chain_id::{MAINNET, SEPOLIA};
 use starknet::core::types::Felt;
 
 use crate::Error;
 
-/// Represent the chain id which is either Sepolia or Mainnet
-#[derive(Debug, Clone, Copy, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+/// Represent the chain id which is either Sepolia, Mainnet, or an arbitrary
+/// (Unknown) chain id supplied by configuration.
+///
+/// Unknown chain ids preserve the configured felt value (so transaction
+/// signing and domain separation use the real chain id), while every other
+/// chain-derived default falls back to the Sepolia values.
+#[derive(Debug, Clone, Copy, Hash)]
 pub enum ChainID {
     Sepolia,
     Mainnet,
+    Unknown(Felt),
 }
 
 impl ChainID {
     /// Convert the identifier representation to a ChainID
     /// - SN_SEPOLIA -> ChainID::Sepolia
-    /// - SN_MAINNET -> ChainID::Mainnet
+    /// - SN_MAIN -> ChainID::Mainnet
     ///
-    /// If the conversion fail, return an error
+    /// Falls back to `Unknown` if the value can be parsed as a hex felt.
     pub fn from_identifier(s: &str) -> Result<Self, Error> {
         match s {
             "SN_SEPOLIA" => Ok(Self::Sepolia),
             "SN_MAIN" => Ok(Self::Mainnet),
-            _ => Err(Error::TypedDataDecoding(format!("invalid domain {}", s))),
+            other => Felt::from_hex(other)
+                .map(Self::Unknown)
+                .map_err(|_| Error::TypedDataDecoding(format!("invalid domain {}", other))),
         }
     }
 
     /// Convert the ChainID to the identifier representation
-    /// - ChainID:Sepolia -> "SN_SEPOLIA"
-    /// - ChainID::Mainnet -> "SN_MAINNET"
+    /// - ChainID::Sepolia -> "SN_SEPOLIA"
+    /// - ChainID::Mainnet -> "SN_MAIN"
+    /// - ChainID::Unknown(f) -> hex string of f
     pub fn as_identifier(&self) -> String {
-        String::from_str(match self {
-            Self::Sepolia => "SN_SEPOLIA",
-            Self::Mainnet => "SN_MAIN",
-        })
-        .unwrap()
+        match self {
+            Self::Sepolia => String::from_str("SN_SEPOLIA").unwrap(),
+            Self::Mainnet => String::from_str("SN_MAIN").unwrap(),
+            Self::Unknown(f) => f.to_hex_string(),
+        }
     }
 
     /// Convert a valid chain-id string into a ChainID
     /// - sepolia -> ChainID::Sepolia
     /// - mainnet -> ChainID::Mainnet
     ///
-    /// If the conversion fail, return an error
+    /// Any other string is parsed as a hex felt and returned as
+    /// `ChainID::Unknown`. If parsing fails, an error is returned.
     pub fn from_string(s: &str) -> Result<Self, Error> {
         match s {
-            "sepolia" => Ok(Self::Sepolia),
-            "SEPOLIA" => Ok(Self::Sepolia),
-            "Sepolia" => Ok(Self::Sepolia),
-            "SN_SEPOLIA" => Ok(Self::Sepolia),
-            "mainnet" => Ok(Self::Mainnet),
-            "Mainnet" => Ok(Self::Mainnet),
-            "SN_MAINNET" => Ok(Self::Mainnet),
-            "main" => Ok(Self::Mainnet),
-            "MAIN" => Ok(Self::Mainnet),
-            _ => Err(Error::TypedDataDecoding(format!("invalid domain {}", s))),
+            "sepolia" | "SEPOLIA" | "Sepolia" | "SN_SEPOLIA" => Ok(Self::Sepolia),
+            "mainnet" | "Mainnet" | "SN_MAINNET" | "SN_MAIN" | "main" | "MAIN" => Ok(Self::Mainnet),
+            other => Felt::from_hex(other)
+                .map(Self::Unknown)
+                .map_err(|_| Error::TypedDataDecoding(format!("invalid domain {}", other))),
         }
     }
 
-    /// Convert a Felt into a ChainID
-    ///
-    /// If the conversion fail, return an error
+    /// Convert a Felt into a ChainID. Unrecognized felts are preserved as
+    /// `ChainID::Unknown` so the original value is kept intact.
     pub fn from_felt(value: Felt) -> Result<Self, Error> {
         if value == SEPOLIA {
             Ok(Self::Sepolia)
         } else if value == MAINNET {
             Ok(Self::Mainnet)
         } else {
-            Err(Error::TypedDataDecoding(format!("invalid domain {}", value.to_hex_string())))
+            Ok(Self::Unknown(value))
         }
     }
 
@@ -76,6 +80,105 @@ impl ChainID {
         match self {
             Self::Sepolia => SEPOLIA,
             Self::Mainnet => MAINNET,
+            Self::Unknown(f) => *f,
         }
+    }
+}
+
+impl Serialize for ChainID {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Sepolia => serializer.serialize_str("sepolia"),
+            Self::Mainnet => serializer.serialize_str("mainnet"),
+            Self::Unknown(f) => serializer.serialize_str(&f.to_hex_string()),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ChainID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ChainIDVisitor;
+
+        impl<'de> Visitor<'de> for ChainIDVisitor {
+            type Value = ChainID;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a chain id string (e.g. \"sepolia\", \"mainnet\", or a hex felt)")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<ChainID, E>
+            where
+                E: de::Error,
+            {
+                ChainID::from_string(value).map_err(|e| de::Error::custom(e.to_string()))
+            }
+        }
+
+        deserializer.deserialize_str(ChainIDVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_string_unknown_returns_unknown_variant() {
+        let raw = "0x534e5f4b41545241";
+        let parsed = ChainID::from_string(raw).expect("hex felt should parse");
+        match parsed {
+            ChainID::Unknown(f) => assert_eq!(f, Felt::from_hex(raw).unwrap()),
+            other => panic!("expected Unknown, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn from_string_garbage_errors() {
+        assert!(ChainID::from_string("not-a-chain").is_err());
+    }
+
+    #[test]
+    fn from_felt_unknown_preserves_value() {
+        let felt = Felt::from_hex("0x534e5f4b41545241").unwrap();
+        match ChainID::from_felt(felt).unwrap() {
+            ChainID::Unknown(f) => assert_eq!(f, felt),
+            other => panic!("expected Unknown, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn as_felt_unknown_returns_inner() {
+        let felt = Felt::from_hex("0x534e5f4b41545241").unwrap();
+        assert_eq!(ChainID::Unknown(felt).as_felt(), felt);
+    }
+
+    #[test]
+    fn serde_round_trip_unknown() {
+        let felt = Felt::from_hex("0x534e5f4b41545241").unwrap();
+        let chain = ChainID::Unknown(felt);
+        let json = serde_json::to_string(&chain).unwrap();
+        assert_eq!(json, format!("\"{}\"", felt.to_hex_string()));
+
+        let back: ChainID = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.as_felt(), felt);
+    }
+
+    #[test]
+    fn serde_round_trip_known() {
+        let json = serde_json::to_string(&ChainID::Sepolia).unwrap();
+        assert_eq!(json, "\"sepolia\"");
+        let back: ChainID = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, ChainID::Sepolia));
+
+        let json = serde_json::to_string(&ChainID::Mainnet).unwrap();
+        assert_eq!(json, "\"mainnet\"");
+        let back: ChainID = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, ChainID::Mainnet));
     }
 }

--- a/crates/paymaster-starknet/src/transaction/mod.rs
+++ b/crates/paymaster-starknet/src/transaction/mod.rs
@@ -384,3 +384,59 @@ impl ExecuteFromOutsideMessageV2 {
         builder.build(Revision::V1)
     }
 }
+
+#[cfg(test)]
+mod unknown_chain_id_smoke {
+    //! Smoke test that mirrors the manual `paymaster_buildTransaction` check:
+    //! constructing an outside-execution message with `ChainID::Unknown(felt)`
+    //! and verifying the resulting EIP-712 domain carries the supplied felt
+    //! unchanged in both directions.
+    use starknet::core::types::Felt;
+
+    use super::{ExecuteFromOutsideMessageV1, ExecuteFromOutsideMessageV2, ExecuteFromOutsideParameters, TimeBounds};
+    use crate::transaction::Calls;
+    use crate::ChainID;
+
+    fn params(chain_id: ChainID) -> ExecuteFromOutsideParameters {
+        ExecuteFromOutsideParameters {
+            chain_id,
+            caller: Felt::from(0x1234u64),
+            nonce: Felt::from(0x1u64),
+            time_bounds: TimeBounds {
+                execute_after: 1,
+                execute_before: 2,
+            },
+            calls: Calls::new(vec![]),
+        }
+    }
+
+    #[test]
+    fn v1_typed_data_domain_preserves_unknown_chain_id() {
+        let custom = Felt::from_hex("0x534e5f4b41545241").unwrap();
+        let typed_data = ExecuteFromOutsideMessageV1::new(params(ChainID::Unknown(custom)))
+            .to_typed_data()
+            .unwrap();
+
+        assert_eq!(typed_data.encoder().domain().chain_id, custom);
+
+        // Round-trip back through `from_typed_data` and confirm the chain id
+        // still resolves to the same felt.
+        let parsed = ExecuteFromOutsideMessageV1::from_typed_data(&typed_data).unwrap();
+        assert_eq!(parsed.chain_id.as_felt(), custom);
+        assert!(matches!(parsed.chain_id, ChainID::Unknown(f) if f == custom));
+    }
+
+    #[test]
+    fn v2_typed_data_domain_preserves_unknown_chain_id() {
+        let custom = Felt::from_hex("0x534e5f4b41545241").unwrap();
+        let typed_data = ExecuteFromOutsideMessageV2::new(params(ChainID::Unknown(custom)))
+            .to_typed_data()
+            .unwrap();
+
+        assert_eq!(typed_data.encoder().domain().chain_id, custom);
+
+        let parsed = ExecuteFromOutsideMessageV2::from_typed_data(&typed_data).unwrap();
+        assert_eq!(parsed.chain_id.as_felt(), custom);
+        assert!(matches!(parsed.chain_id, ChainID::Unknown(f) if f == custom));
+    }
+}


### PR DESCRIPTION
Backport of cartridge-gg/paymaster#11 onto \`copenhagen-4cb4\`.

## Summary
- Add \`ChainID::Unknown(Felt)\` variant so the paymaster can be configured against arbitrary Starknet chain IDs (e.g. appchains) instead of only \`sepolia\`/\`mainnet\`.
- The configured felt is preserved as-is for transaction signing and EIP-712 domain separation, while every chain-derived default (USDC token, AVNU swap endpoint, AVNU token metadata API, AVNU exchange address, **AVNU price oracle** endpoint) falls back to the Sepolia values.
- The CLI errors out with a clear message if an unknown chain id is set without an explicit \`--rpc-url\`, since unknown chains have no canonical RPC endpoint.
- At service startup, log the configured chain id; warn loudly when it is not natively supported.

## Differences vs the main-branch PR
- This branch uses \`AVNUPriceClientConfiguration::default_from_chain\` for the price oracle, so the Sepolia fallback is added there instead of the Coingecko mapping.

## Test plan
- [x] \`cargo build\`
- [x] \`cargo test -p paymaster-starknet --lib\` — \`network::tests\` and \`transaction::unknown_chain_id_smoke\` (V1 + V2 typed-data domain preservation) pass
- [x] \`cargo test -p paymaster-execution --lib tokens::tests::new\` — \`TokenClient::new(Unknown)\` picks the Sepolia URL
- [x] \`cargo test -p paymaster-relayer --lib swap::client::tests\` — \`SwapClientConfiguration::validate\` and \`default_from_chain\` accept \`Unknown\`
- [ ] Manual smoke: launch \`paymaster-service\` with \`"chain_id": "0x534e5f4b41545241"\` and confirm the typed-data domain in \`paymaster_buildTransaction\` carries the supplied felt unchanged (covered in process by the smoke test above)