### PR TITLE
Add --version/-V flag to paymaster-service

### DIFF
--- a/crates/paymaster-service/build.rs
+++ b/crates/paymaster-service/build.rs
@@ -1,0 +1,45 @@
+use std::process::Command;
+
+fn main() {
+    // Git SHA
+    let git_sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_SHA={git_sha}");
+
+    // Build timestamp
+    let build_timestamp = Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={build_timestamp}");
+
+    // Dev build suffix: "-dev" if the working tree is dirty or HEAD is not on a tag
+    let dirty = Command::new("git")
+        .args(["diff", "--quiet"])
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true);
+
+    let on_tag = Command::new("git")
+        .args(["describe", "--exact-match", "--tags", "HEAD"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let dev_suffix = if dirty || !on_tag { "-dev" } else { "" };
+    println!("cargo:rustc-env=DEV_BUILD_SUFFIX={dev_suffix}");
+
+    // Rerun if git state changes
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/index");
+}

--- a/crates/paymaster-service/src/main.rs
+++ b/crates/paymaster-service/src/main.rs
@@ -11,9 +11,16 @@ use crate::rpc::RPCService;
 
 mod core;
 mod rpc;
+mod version;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        println!("paymaster-service {}", version::long());
+        return Ok(());
+    }
+
     let context = Context::load()?;
 
     let metric_layer = context.configuration.prometheus.clone().map(|x| Metric::layer(&x));

--- a/crates/paymaster-service/src/version.rs
+++ b/crates/paymaster-service/src/version.rs
@@ -1,0 +1,30 @@
+use std::fmt::Write;
+
+/// The latest version from Cargo.toml.
+const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Suffix indicating if it is a dev build.
+///
+/// A build is considered a dev build if the working tree is dirty
+/// or if the current git revision is not on a tag.
+const DEV_BUILD_SUFFIX: &str = env!("DEV_BUILD_SUFFIX");
+
+/// The SHA of the latest commit.
+const GIT_SHA: &str = env!("GIT_SHA");
+
+/// The build timestamp.
+const BUILD_TIMESTAMP: &str = env!("BUILD_TIMESTAMP");
+
+/// Short version string, e.g. `1.0.0-dev (77d4800)`
+pub fn short() -> String {
+    format!("{CARGO_PKG_VERSION}{DEV_BUILD_SUFFIX} ({GIT_SHA})")
+}
+
+/// Long version string with build metadata.
+pub fn long() -> String {
+    let mut out = String::new();
+    writeln!(out, "{}", short()).unwrap();
+    writeln!(out).unwrap();
+    write!(out, "built on: {BUILD_TIMESTAMP}").unwrap();
+    out
+}


### PR DESCRIPTION
## Summary
- Adds `--version` / `-V` CLI flag to the `paymaster-service` binary
- Captures git SHA, build timestamp, and dev build suffix at compile time via `build.rs`
- Modeled after katana's version output

Example output:
```
paymaster-service 1.0.0-dev (41939c3)

built on: 2026-04-09T16:32:46Z
```

## Test plan
- [x] `cargo run -p paymaster-service -- --version` prints version info and exits
- [x] `cargo run -p paymaster-service -- -V` prints version info and exits
- [ ] Verify on a tagged commit that `-dev` suffix is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)