### PR TITLE
Update log format to match Katana's tracing style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ name = "paymaster-service"
 version = "1.0.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "envy",
  "lazy_static",
  "log",

--- a/crates/paymaster-rpc/src/lib.rs
+++ b/crates/paymaster-rpc/src/lib.rs
@@ -13,9 +13,7 @@ mod context;
 pub use context::{Configuration, RPCConfiguration};
 
 mod endpoint;
-pub use crate::endpoint::execute_raw::{
-    DirectInvokeParameters, ExecuteDirectRequest, ExecuteDirectResponse, ExecuteDirectTransactionParameters,
-};
+pub use crate::endpoint::execute_raw::{DirectInvokeParameters, ExecuteDirectRequest, ExecuteDirectResponse, ExecuteDirectTransactionParameters};
 pub use endpoint::build::{
     BuildTransactionRequest, BuildTransactionResponse, DeployAndInvokeTransaction, DeployTransaction, FeeEstimate, InvokeParameters, InvokeTransaction,
     TransactionParameters,

--- a/crates/paymaster-service/Cargo.toml
+++ b/crates/paymaster-service/Cargo.toml
@@ -6,6 +6,7 @@ repository = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
+chrono = { workspace = true }
 envy = { workspace = true }
 log = { workspace = true }
 lazy_static = { workspace = true }
@@ -24,7 +25,7 @@ starknet = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time", "sync", "macros", "rt-multi-thread"] }
 tracing = { workspace = true, features = ['attributes'] }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-opentelemetry = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }

--- a/crates/paymaster-service/src/core/tracing.rs
+++ b/crates/paymaster-service/src/core/tracing.rs
@@ -1,20 +1,37 @@
-use tracing_subscriber::filter::LevelFilter;
-use tracing_subscriber::Layer;
+use tracing_subscriber::fmt::format::Writer;
+use tracing_subscriber::fmt::time;
+use tracing_subscriber::{EnvFilter, Layer};
 
-use crate::core::context::configuration::VerbosityConfiguration;
+const DEFAULT_LOG_FILTER: &str = "info";
+const DEFAULT_TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f %Z";
+
+/// Formats timestamps in local time.
+///
+/// Example output: `2025-08-24 20:49:32.487 -04:00`
+#[derive(Debug, Clone, Default)]
+struct LocalTime;
+
+impl time::FormatTime for LocalTime {
+    fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
+        let time = chrono::Local::now();
+        write!(w, "{}", time.format(DEFAULT_TIMESTAMP_FORMAT))
+    }
+}
 
 pub struct Fmt;
 
 impl Fmt {
-    pub fn layer<S>(verbosity: &VerbosityConfiguration) -> impl Layer<S>
+    pub fn layer<S>() -> (impl Layer<S>, EnvFilter)
     where
         S: for<'span> tracing_subscriber::registry::LookupSpan<'span> + tracing::Subscriber,
     {
-        let filter = match verbosity {
-            VerbosityConfiguration::Info => LevelFilter::INFO,
-            VerbosityConfiguration::Debug => LevelFilter::DEBUG,
-        };
+        let ansi = std::io::IsTerminal::is_terminal(&std::io::stdout());
 
-        tracing_subscriber::fmt::layer().with_ansi(false).compact().with_filter(filter)
+        let default_filter = EnvFilter::try_new(DEFAULT_LOG_FILTER);
+        let filter = EnvFilter::try_from_default_env().or(default_filter).expect("valid env filter");
+
+        let layer = tracing_subscriber::fmt::layer().with_timer(LocalTime).with_ansi(ansi);
+
+        (layer, filter)
     }
 }

--- a/crates/paymaster-service/src/main.rs
+++ b/crates/paymaster-service/src/main.rs
@@ -24,9 +24,9 @@ async fn main() -> Result<(), Error> {
     let context = Context::load()?;
 
     let metric_layer = context.configuration.prometheus.clone().map(|x| Metric::layer(&x));
-    let fmt_layer = Fmt::layer(&context.configuration.verbosity);
+    let (fmt_layer, env_filter) = Fmt::layer();
 
-    let subscriber = Registry::default().with(fmt_layer).with(metric_layer);
+    let subscriber = Registry::default().with(env_filter).with(fmt_layer).with(metric_layer);
 
     tracing::subscriber::set_global_default(subscriber).unwrap();
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `LevelFilter` (Info/Debug) with `EnvFilter` — respects `RUST_LOG` env var, defaults to `info`
- Add `LocalTime` timestamp formatter (`2025-08-24 20:49:32.487 -04:00`) using `chrono::Local`
- Remove `.compact()` in favor of full tracing format
- Auto-detect terminal for ANSI color support instead of hardcoding it off

Aligns the paymaster log output with Katana's tracing crate format.

## Test plan

- [x] `cargo build -p paymaster-service` compiles cleanly
- [ ] Verify logs show local timestamps and full format when running the service
- [ ] Verify `RUST_LOG=debug` overrides the default filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)