### PR TITLE
feat(paymaster-service): support json log format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,6 +4316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4325,12 +4335,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/paymaster-service/Cargo.toml
+++ b/crates/paymaster-service/Cargo.toml
@@ -25,7 +25,7 @@ starknet = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time", "sync", "macros", "rt-multi-thread"] }
 tracing = { workspace = true, features = ['attributes'] }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 tracing-opentelemetry = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }

--- a/crates/paymaster-service/src/core/tracing.rs
+++ b/crates/paymaster-service/src/core/tracing.rs
@@ -16,9 +16,7 @@ enum LogFormat {
 impl LogFormat {
     fn from_env() -> Self {
         match std::env::var(LOG_FORMAT_ENV) {
-            Ok(value) => Self::parse(&value).unwrap_or_else(|| {
-                panic!("invalid {LOG_FORMAT_ENV}={value:?}; expected one of: text, json")
-            }),
+            Ok(value) => Self::parse(&value).unwrap_or_else(|| panic!("invalid {LOG_FORMAT_ENV}={value:?}; expected one of: text, json")),
             Err(std::env::VarError::NotPresent) => DEFAULT_LOG_FORMAT,
             Err(std::env::VarError::NotUnicode(value)) => {
                 panic!("invalid {LOG_FORMAT_ENV}={value:?}; value must be valid UTF-8")
@@ -58,15 +56,10 @@ impl Fmt {
         let ansi = std::io::IsTerminal::is_terminal(&std::io::stdout());
 
         let default_filter = EnvFilter::try_new(DEFAULT_LOG_FILTER);
-        let filter = EnvFilter::try_from_default_env()
-            .or(default_filter)
-            .expect("valid env filter");
+        let filter = EnvFilter::try_from_default_env().or(default_filter).expect("valid env filter");
 
         let layer = match LogFormat::from_env() {
-            LogFormat::Text => tracing_subscriber::fmt::layer()
-                .with_timer(LocalTime)
-                .with_ansi(ansi)
-                .boxed(),
+            LogFormat::Text => tracing_subscriber::fmt::layer().with_timer(LocalTime).with_ansi(ansi).boxed(),
             LogFormat::Json => tracing_subscriber::fmt::layer()
                 .json()
                 .flatten_event(true)

--- a/crates/paymaster-service/src/core/tracing.rs
+++ b/crates/paymaster-service/src/core/tracing.rs
@@ -3,7 +3,37 @@ use tracing_subscriber::fmt::time;
 use tracing_subscriber::{EnvFilter, Layer};
 
 const DEFAULT_LOG_FILTER: &str = "info";
+const DEFAULT_LOG_FORMAT: LogFormat = LogFormat::Text;
 const DEFAULT_TIMESTAMP_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f %Z";
+const LOG_FORMAT_ENV: &str = "PAYMASTER_LOG_FORMAT";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum LogFormat {
+    Text,
+    Json,
+}
+
+impl LogFormat {
+    fn from_env() -> Self {
+        match std::env::var(LOG_FORMAT_ENV) {
+            Ok(value) => Self::parse(&value).unwrap_or_else(|| {
+                panic!("invalid {LOG_FORMAT_ENV}={value:?}; expected one of: text, json")
+            }),
+            Err(std::env::VarError::NotPresent) => DEFAULT_LOG_FORMAT,
+            Err(std::env::VarError::NotUnicode(value)) => {
+                panic!("invalid {LOG_FORMAT_ENV}={value:?}; value must be valid UTF-8")
+            },
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "" | "text" | "plain" | "compact" => Some(Self::Text),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+}
 
 /// Formats timestamps in local time.
 ///
@@ -21,17 +51,47 @@ impl time::FormatTime for LocalTime {
 pub struct Fmt;
 
 impl Fmt {
-    pub fn layer<S>() -> (impl Layer<S>, EnvFilter)
+    pub fn layer<S>() -> (Box<dyn Layer<S> + Send + Sync + 'static>, EnvFilter)
     where
         S: for<'span> tracing_subscriber::registry::LookupSpan<'span> + tracing::Subscriber,
     {
         let ansi = std::io::IsTerminal::is_terminal(&std::io::stdout());
 
         let default_filter = EnvFilter::try_new(DEFAULT_LOG_FILTER);
-        let filter = EnvFilter::try_from_default_env().or(default_filter).expect("valid env filter");
+        let filter = EnvFilter::try_from_default_env()
+            .or(default_filter)
+            .expect("valid env filter");
 
-        let layer = tracing_subscriber::fmt::layer().with_timer(LocalTime).with_ansi(ansi);
+        let layer = match LogFormat::from_env() {
+            LogFormat::Text => tracing_subscriber::fmt::layer()
+                .with_timer(LocalTime)
+                .with_ansi(ansi)
+                .boxed(),
+            LogFormat::Json => tracing_subscriber::fmt::layer()
+                .json()
+                .flatten_event(true)
+                .with_current_span(true)
+                .with_span_list(true)
+                .with_timer(LocalTime)
+                .boxed(),
+        };
 
         (layer, filter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogFormat, DEFAULT_LOG_FORMAT};
+
+    #[test]
+    fn parses_log_format_values() {
+        assert_eq!(LogFormat::parse(""), Some(DEFAULT_LOG_FORMAT));
+        assert_eq!(LogFormat::parse("text"), Some(LogFormat::Text));
+        assert_eq!(LogFormat::parse("plain"), Some(LogFormat::Text));
+        assert_eq!(LogFormat::parse("compact"), Some(LogFormat::Text));
+        assert_eq!(LogFormat::parse("json"), Some(LogFormat::Json));
+        assert_eq!(LogFormat::parse(" JSON "), Some(LogFormat::Json));
+        assert_eq!(LogFormat::parse("xml"), None);
     }
 }


### PR DESCRIPTION
## Summary
- add PAYMASTER_LOG_FORMAT support to paymaster-service
- preserve existing text logs by default
- enable tracing-subscriber JSON formatting and include current span/span list fields for structured logs

## Usage
Set:

```sh
PAYMASTER_LOG_FORMAT=json
```

Supported values: `text`, `plain`, `compact`, `json`. Empty/unset defaults to text.

## Test Plan
- `cargo +stable test -p paymaster-service`
- `cargo +stable test -p paymaster-service parses_log_format_values`

Note: local default Rust was too old for current workspace deps, so verification used updated stable toolchain `1.96.0`.