### PR TITLE
fix(starknet): increase paymaster resource bounds

### DIFF
--- a/crates/paymaster-starknet/src/transaction/gas.rs
+++ b/crates/paymaster-starknet/src/transaction/gas.rs
@@ -2,6 +2,8 @@ use starknet::core::types::{FeeEstimate, Felt, PriceUnit};
 
 use crate::Error;
 
+const RESOURCE_BOUNDS_MULTIPLIER: f64 = 2.5;
+
 #[derive(Debug, Clone)]
 pub struct TransactionGasEstimate {
     pub overall_fee: u128,
@@ -29,8 +31,8 @@ impl TransactionGasEstimate {
             l1_data_gas_consumed: estimate.l1_data_gas_consumed,
             tip,
             unit: PriceUnit::Fri,
-            gas_estimate_multiplier: 1.5,
-            gas_price_estimate_multiplier: 1.5,
+            gas_estimate_multiplier: RESOURCE_BOUNDS_MULTIPLIER,
+            gas_price_estimate_multiplier: RESOURCE_BOUNDS_MULTIPLIER,
         }
     }
 
@@ -100,4 +102,49 @@ fn felt_to_u128(felt: &Felt) -> u128 {
     let bytes = felt.to_bytes_le();
     let slice: [u8; 16] = bytes[..16].try_into().expect("Felt should have at least 16 bytes");
     u128::from_le_bytes(slice)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gas_amounts_apply_resource_bounds_headroom() {
+        let estimate = TransactionGasEstimate::new(
+            FeeEstimate {
+                l1_gas_consumed: 10,
+                l1_gas_price: 100,
+                l2_gas_consumed: 20,
+                l2_gas_price: 200,
+                l1_data_gas_consumed: 960,
+                l1_data_gas_price: 300,
+                overall_fee: 1_000,
+            },
+            1,
+        );
+
+        assert_eq!(estimate.l1_gas_consumed(), 25);
+        assert_eq!(estimate.l2_gas_consumed(), 50);
+        assert_eq!(estimate.l1_data_gas_consumed(), 2_400);
+    }
+
+    #[test]
+    fn gas_prices_apply_resource_bounds_headroom() {
+        let estimate = TransactionGasEstimate::new(
+            FeeEstimate {
+                l1_gas_consumed: 10,
+                l1_gas_price: 100,
+                l2_gas_consumed: 20,
+                l2_gas_price: 200,
+                l1_data_gas_consumed: 30,
+                l1_data_gas_price: 300,
+                overall_fee: 1_000,
+            },
+            1,
+        );
+
+        assert_eq!(estimate.l1_gas_price().unwrap(), 250);
+        assert_eq!(estimate.l2_gas_price().unwrap(), 500);
+        assert_eq!(estimate.l1_data_gas_price().unwrap(), 750);
+    }
 }


### PR DESCRIPTION
## Summary
- increase Starknet paymaster resource-bound multiplier from 1.5x to 2.5x
- add unit coverage for gas amount and gas price scaling, including L1 data gas

## Context
This should address failures like `Insufficient max L1DataGas: max amount: 1440, actual used: 1504` by giving submitted transactions additional resource-bound headroom without going all the way to the legacy 4.5x multiplier.

## Test
- cargo +1.88.0 fmt --all
- cargo +1.88.0 test -p paymaster-starknet transaction::gas
- cargo +1.88.0 test -p paymaster-starknet